### PR TITLE
Create a working debug build option for UM

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,6 +9,7 @@ ENVFILE=./environment.sh
 all : um mom5 cice
 
 um: bin/um_hg3.exe
+um_dbg: bin/um_hg3_dbg.exe
 mom5: bin/mom5xx
 cice: bin/cice-12p
 oasis: lib/oasis
@@ -147,6 +148,9 @@ endif
 
 bin/um_hg3.exe: src/UM $(ENVFILE) lib/dummygrib lib/oasis | bin
 	source $(ENVFILE) ; cd src/UM/compile; ./compile_ACCESS1.5
+
+bin/um_hg3_dbg.exe: src/UM $(ENVFILE) lib/dummygrib lib/oasis | bin
+	source $(ENVFILE) ; cd src/UM/compile; ./compile_ACCESS1.5 debug
 
 bin/cice-12p: src/cice4.1 $(ENVFILE) lib/oasis | bin
 	source $(ENVFILE) ; cd $</compile ; csh ./comp_access-cm_cice.RJ.nP-mct 12

--- a/patch/UM_exe_generator-ACCESS1.5
+++ b/patch/UM_exe_generator-ACCESS1.5
@@ -12,21 +12,6 @@ source ../../../environment.sh
 
 SYSTEMDIR=$MY_PATH/../../
 
-# these variables are referenced in the fcm bld.cfg scripts
-#export CPLINCDIR_OMPI=/apps/openmpi/1.10.2/include 
-#export CPLINCDIR_GCOM=/projects/access/apps/gcom/6.3_ompi.1.10.2/include 
-#export CPLINCDIR_OASIS=/projects/access/apps/oasis3-mct/ompi.1.10.2/include
-#export CPL_INCS='-I${CPLINCDIR_OMPI} -I${CPLINCDIR_GCOM} -I${CPLINCDIR_OASIS}'
-#export CPLLIBDIR_OMPI=/apps/openmpi/1.10.2/lib
-#export CPLLIBDIR_GCOM=/projects/access/apps/gcom/6.3_ompi.1.10.2/lib 
-#export CPLLIBDIR_OASIS=/projects/access/apps/oasis3-mct/ompi.1.10.2/lib 
-#export CPLLIBS_OMPI='-L${CPLLIBDIR_OMPI}'
-#export CPLLIBS_GCOM='-L${CPLLIBDIR_GCOM} -lgcom'
-#export CPLLIBS_OASIS='-L${CPLLIBDIR_OASIS} -lpsmile.MPI1 -lmct -lmpeu -lscrip'
-#export CPL_OPT='-O0 '
-#export CPL_FLAGS='-std95 -g -traceback -fp-model precise -ftz '
-#export CPL_KIND='-i8 -r8 '
-
 HG=3 # build HadGEM3 ONLY here
 
 # Whether to build debug --jhan: adjust path to configs
@@ -34,8 +19,8 @@ BLD_CONFIG=bld-hadgem${HG}-mct.cfg
 EXEC=um_hg${HG}.exe
 if [ "$2" == "debug" ]
 then
-    BLD_CONFIG=bld-dbg-hadgem${HG}.cfg
-    EXEC=um_hg${HG}_dbg.exe-$2
+    BLD_CONFIG=bld-dbg-hadgem${HG}-C2.cfg
+    EXEC=um_hg${HG}_dbg.exe
 fi
 
 # Model build only ## Base build # rm'd superfluous


### PR DESCRIPTION
Closes #3 
ACCESS ESM 1.5 with the debug option for UM builds and reproduces the output of `output000/atmosphere/atm.fort6.pe0` for the `pre-industrial` case, but this is not bitwise identical to the default build:
```
$ diff -w -U64 /scratch/tm70/pcl851/access-esm/archive/access-esm.default.1/output000/atmosphere/atm.fort6.pe0 /scratch/tm70/pcl851/access-esm/archive/access-esm.debug.2/output000/atmosphere/atm.fort6.pe0 | grep "Timestep\|Final Absolute Norm" | more
  Atm_Step: Timestep                   6337
-  Final Absolute Norm :   9.251119986735775E-003
+  Final Absolute Norm :   9.251119986730368E-003
```
